### PR TITLE
Add Loading Modal to addRowsTo() in case of slow connection

### DIFF
--- a/Add Rows/Add Rows Modal.html
+++ b/Add Rows/Add Rows Modal.html
@@ -136,6 +136,7 @@
         let tracker = document.querySelector('input[type="radio"]:checked').value;
 //        console.log("Rows: " + rows);
 //        console.log("Tracker: " + tracker);
+        google.script.run.loading2();
         google.script.run.addRowsTo(tracker, rows);
         google.script.host.close();
       }

--- a/Add Rows/Add Rows To.gs
+++ b/Add Rows/Add Rows To.gs
@@ -1,7 +1,7 @@
 function addRowsTo(tracker, rows){
   let sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
-  Logger.log(sheet.getName());
-  console.log(sheet.getName());
+//  Logger.log(sheet.getName());
+//  console.log(sheet.getName());
   let column;
   let valuesRange;
   let startRow = getStartRow(sheet);
@@ -21,4 +21,5 @@ function addRowsTo(tracker, rows){
   let range = sheet.getRange(row, column, rows, 1);
   sheet.getRange(row, column, rows, 4).setBackground(sectionColor).setBorder(true, true, true, true, true, true, "black", solid);
   setDataValidation(sheet, rule, range);
+  closeHTMLBox();
 }

--- a/Loading/Loading JS.gs
+++ b/Loading/Loading JS.gs
@@ -1,6 +1,6 @@
 function loading(){
   let ui = SpreadsheetApp.getUi();
-  var loading = HtmlService.createHtmlOutputFromFile('Loading/Loading').setTitle('LOADING...');
+  let loading = HtmlService.createHtmlOutputFromFile('Loading/Loading').setTitle('LOADING...');
   
   // Check if loading sheet exists, if it does delete and re-make it
   let activeSheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
@@ -11,10 +11,10 @@ function loading(){
     ss.insertSheet("Loading", 0);
     sheet = ss.getSheetByName("Loading");
   }
-  sheet.setTabColor(colors.black).setHiddenGridlines(true);;
+  sheet.setTabColor(colors.black).setHiddenGridlines(true);
   sheet.getRange(1, 1, sheet.getMaxRows(), sheet.getMaxColumns()).setBackground(colors.black);
   
-  // Use three different god damn methods to set active sheet to the newly created "Loading" sheet
+  // Use three different ***-**** methods to set active sheet to the newly created "Loading" sheet
   // 1)
   setActiveSheet("Loading");
   // 2)

--- a/Loading/loading2.gs
+++ b/Loading/loading2.gs
@@ -1,0 +1,5 @@
+function loading2(){
+  let ui = SpreadsheetApp.getUi();
+  let loading = HtmlService.createHtmlOutputFromFile('Loading/Loading').setTitle('LOADING...').setWidth(2000).setHeight(1000);
+  ui.showModalDialog(loading, ' ');
+}


### PR DESCRIPTION
Depending on connection speed, processing speed, and other possible factors, it deemed helpful to add a more simple loading modal when a user is adding rows to a tracker section of a sheet.  Before this change, it was unclear if the rows were added successfully after selecting "Submit" on the add rows modal due to periodic long pauses of processing before visually seeing the new rows actually added.

Resolves Issue: #9 