### PR TITLE
Fix edge case when either new or old budget has no bills

### DIFF
--- a/Budget/Did Bills Change.gs
+++ b/Budget/Did Bills Change.gs
@@ -1,9 +1,9 @@
 function didBillsChange(oldBills, currentBills){
   let bills = currentBills || getBills();
   let currentBillsNames = extractKey(bills, "name");
-//  Logger.log(currentBillsNames.toString());
-  // First check if there are the same amount of bills in each 
-  if( oldBills.length !== bills.length ) return true;
+  // First simple checks
+  if( !oldBills && bills || oldBills && !bills) return true;
+  if( oldBills.length === 0 && bills.length > 0 ) return true;
   // Second check if the oldBills contents exactly match the currentBills (bills) exactly regardless of order
   for( let i = 0; i < bills.length; i++ ){
     let name = bills[i].name;

--- a/Budget/Get Bills From Budget.gs
+++ b/Budget/Get Bills From Budget.gs
@@ -9,16 +9,19 @@ function getBillsFromBudget(budget){
   let bills = [];
   for( let i in budget ){
     if( budget[i].isBill ){
+      let name = budget[i].name;
+      let amount = budget[i].amount;
+      // Logger.log("i: " + i + ", name: " + name + ", amount: " + amount);
       let lineItem = {
-        name: budget[i].name,
-        amount: budget[i].amount,
+        name: name,
+        amount: amount,
       };
       bills.push(lineItem);
     }
   }
   // Check if bills array was filled
   if( bills.length === 0 ){
-    error("Bills array for not created. --getBillsFromBudget()");
+    Logger.log("Bills array was empty, was the old budget devoid of bills? --getBillsFromBudget()");
     return null;
   } else {
     return bills;

--- a/Budget/Update Budget.gs
+++ b/Budget/Update Budget.gs
@@ -8,7 +8,6 @@ function updateBudget(){
   
   let sheet = ssData.getSheetByName(budgetSheetName);
   if( !sheet ){
-    let sheets = ssData.getSheets();
     ssData.insertSheet(budgetSheetName, defaultSheets.indexOf(budgetSheetName)).setTabColor(colors.red);
     sheet = ssData.getSheetByName(budgetSheetName);
   }
@@ -16,16 +15,11 @@ function updateBudget(){
   // STORE IN DATABASE
   let oldBudget = getBudgetFromDatabase();
   let oldBills = getBillsFromBudget(oldBudget);
-//  Logger.log(didBillsChange(oldBills, bills));
   // Check if the user wants to update the "Current Month" budget section in addition to in the database
   let ui = SpreadsheetApp.getUi();
   let response = ui.alert("Update Current Month?", "Are you sure you want to update the budget?\n", ui.ButtonSet.YES_NO);
-  Logger.log("BEFORE");
   if( response === ui.Button.YES ){
-    //@TODO: NOT WORKING
     loading();
-    Logger.log(response);
-    Logger.log("AFTER");
     sheet.clear();
     for( let i = 0; i < budget.length; i++ ){
       sheet.getRange(i + 1, 1).setValue(budget[i].name);


### PR DESCRIPTION
Fix an issue when a user changes and updates the budget. When either the budget in the database or the updated budget has no bills the Bills section would not know to update correctly and an error was given. This PR fixes that issue by specifying those edge case validations in the `getBillsFromBudget()` function.

Resolves Issue: #13 